### PR TITLE
#30 fix : createTag 태그 기능 수정, feat: createTag 태그 생성 시 tagCount 기능 추가

### DIFF
--- a/src/main/java/com/paintourcolor/odle/controller/PostController.java
+++ b/src/main/java/com/paintourcolor/odle/controller/PostController.java
@@ -1,9 +1,6 @@
 package com.paintourcolor.odle.controller;
 
-import com.paintourcolor.odle.dto.post.request.PostCreateRequest;
-import com.paintourcolor.odle.dto.post.request.PostDeleteRequest;
-import com.paintourcolor.odle.dto.post.request.PostUpdateRequest;
-import com.paintourcolor.odle.dto.post.request.TagCreateRequest;
+import com.paintourcolor.odle.dto.post.request.*;
 import com.paintourcolor.odle.dto.post.response.PostResponse;
 import com.paintourcolor.odle.dto.post.response.TagResponse;
 import com.paintourcolor.odle.security.UserDetailsImpl;
@@ -21,7 +18,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostController {
     private final PostServiceInterface postService;
-    private final TagServiceInterface tagService;
 
     //게시글 작성
     @PostMapping
@@ -59,9 +55,11 @@ public class PostController {
         return postService.deletePost(postId, postDeleteRequest, username);
     }
 
-    // 게시글 태그 생성 (테스트 아직 X)
+/*    // 게시글 태그 생성 (테스트 아직 X)
     @PostMapping("/{postId}/tag")
-    public String createTag(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long postId, @RequestBody TagCreateRequest tagCreateRequest) {
+    public String createTag(@PathVariable Long postId,
+                            @AuthenticationPrincipal UserDetailsImpl userDetails,
+                            @RequestBody TagCreateRequest tagCreateRequest) {
         tagService.createTag(postId, userDetails.getEmail(), tagCreateRequest);
         return "태그 작성 완료";
     }
@@ -70,5 +68,5 @@ public class PostController {
     @GetMapping("/{postId}/tag")
     public List<TagResponse> getTag(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long postId) {
         return tagService.getTag(userDetails.getEmail(), postId);
-    }
+    }*/
 }

--- a/src/main/java/com/paintourcolor/odle/dto/post/request/TagCreateRequest.java
+++ b/src/main/java/com/paintourcolor/odle/dto/post/request/TagCreateRequest.java
@@ -4,10 +4,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Pattern;
+
 @Getter
 @Builder
 @NoArgsConstructor
 public class TagCreateRequest {
+    // #로 시작  // 숫자, 영어 대소문자, 한글 가능  // 특문, 띄어쓰기 불가능
+    @Pattern(regexp = "^#([a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣])+$")
     private String tagName;
 
     public TagCreateRequest(String tagName) {

--- a/src/main/java/com/paintourcolor/odle/entity/Post.java
+++ b/src/main/java/com/paintourcolor/odle/entity/Post.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -28,6 +30,10 @@ public class Post extends Timestamped{
     private EmotionEnum emotion;
     @Column(nullable = false)
     private Long commentCount;
+
+    @JoinColumn(name = "postId")
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<PostTag> postTags = new LinkedHashSet<>();
 
     public void plusComment() {
         this.commentCount += 1;

--- a/src/main/java/com/paintourcolor/odle/entity/PostTag.java
+++ b/src/main/java/com/paintourcolor/odle/entity/PostTag.java
@@ -12,10 +12,5 @@ public class PostTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
-    @JoinColumn(name = "tagId", nullable = false)
-    private Tag tag;
-    @ManyToOne
-    @JoinColumn(name = "postId", nullable = false)
-    private Post post;
+
 }

--- a/src/main/java/com/paintourcolor/odle/entity/Tag.java
+++ b/src/main/java/com/paintourcolor/odle/entity/Tag.java
@@ -18,11 +18,23 @@ public class Tag {
     @Column(name = "tagName", nullable = false)
     private String tagName;
 
+    @Column(nullable = false)
+    private Long tagCount;
+
     @JoinColumn(name = "tagId")
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<PostTag> postTags = new LinkedHashSet<>();
 
+    public void plusTagCount() {
+        this.tagCount += 1;
+    }
+
+    public void minusTagCount() {
+        this.tagCount -= 1;
+    }
+
     public Tag(String tagName) {
         this.tagName = tagName;
+        this.tagCount = 1L;
     }
 }

--- a/src/main/java/com/paintourcolor/odle/entity/Tag.java
+++ b/src/main/java/com/paintourcolor/odle/entity/Tag.java
@@ -3,10 +3,9 @@ package com.paintourcolor.odle.entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -15,7 +14,13 @@ public class Tag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "tagName", nullable = false)
     private String tagName;
+
+    @JoinColumn(name = "tagId")
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<PostTag> postTags = new LinkedHashSet<>();
 
     public Tag(String tagName) {
         this.tagName = tagName;

--- a/src/main/java/com/paintourcolor/odle/repository/TagRepository.java
+++ b/src/main/java/com/paintourcolor/odle/repository/TagRepository.java
@@ -4,4 +4,5 @@ import com.paintourcolor.odle.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    Boolean findTagByTagName(String tagName);
 }

--- a/src/main/java/com/paintourcolor/odle/service/TagService.java
+++ b/src/main/java/com/paintourcolor/odle/service/TagService.java
@@ -4,6 +4,7 @@ import com.paintourcolor.odle.dto.post.request.TagCreateRequest;
 import com.paintourcolor.odle.dto.post.request.TagUpdateRequest;
 import com.paintourcolor.odle.dto.post.response.TagResponse;
 import com.paintourcolor.odle.entity.Post;
+import com.paintourcolor.odle.entity.PostTag;
 import com.paintourcolor.odle.entity.Tag;
 import com.paintourcolor.odle.entity.User;
 import com.paintourcolor.odle.repository.PostRepository;
@@ -29,20 +30,9 @@ public class TagService implements TagServiceInterface {
     // 게시글 태그 생성
     @Transactional
     @Override
-    public void createTag(Long postId, String email, TagCreateRequest tagCreateRequest) {
-        postRepository.findById(postId).orElseThrow(
-                () -> new IllegalArgumentException("해당 게시글을 찾을 수 없습니다.")
-        );
-
-        Pattern pattern = Pattern.compile("#(\\S+)");
-        Matcher matcher = pattern.matcher(tagCreateRequest.getTagName());
-        List<String> tagList = new ArrayList<>();
-
-        while (matcher.find()) {
-            tagList.add(matcher.group(1));
-        }
-
-        tagRepository.save(new Tag(tagList.toString()));
+    public void createTag(TagCreateRequest tagCreateRequest) {
+        Tag tag = new Tag(tagCreateRequest.getTagName());
+        tagRepository.save(tag);
     }
 
     // 게시글 태그 조회

--- a/src/main/java/com/paintourcolor/odle/service/TagService.java
+++ b/src/main/java/com/paintourcolor/odle/service/TagService.java
@@ -31,8 +31,16 @@ public class TagService implements TagServiceInterface {
     @Transactional
     @Override
     public void createTag(TagCreateRequest tagCreateRequest) {
-        Tag tag = new Tag(tagCreateRequest.getTagName());
-        tagRepository.save(tag);
+        String tagName = tagCreateRequest.getTagName();
+
+        Tag tag = new Tag(tagName);
+
+        // tagName이 이미 존재한다면 count만 올려주고, 없을 때에만 DB에 저장
+        if (tagRepository.findTagByTagName(tagName)) {
+            tag.plusTagCount();
+        } else {
+            tagRepository.save(tag);
+        }
     }
 
     // 게시글 태그 조회

--- a/src/main/java/com/paintourcolor/odle/service/TagServiceInterface.java
+++ b/src/main/java/com/paintourcolor/odle/service/TagServiceInterface.java
@@ -7,7 +7,7 @@ import com.paintourcolor.odle.dto.post.response.TagResponse;
 import java.util.List;
 
 public interface TagServiceInterface {
-    void createTag(Long postId, String email, TagCreateRequest tagCreateRequest);
+    void createTag(TagCreateRequest tagCreateRequest);
     List<TagResponse> getTag(String email, Long postId);
     void updateTag(Long postId, Long tagId, String username, TagUpdateRequest tagUpdateRequest);
     void deleteTag(Long postId, Long tagId, String username);


### PR DESCRIPTION
PostController
TagCeateRequest
Post
Post
Tag
TagService
TagServiceInterface
TagRepository

태그 생성 시 PostController에서 url을 따로 쓰는 게 아니라 게시글 게시할 때 TagService를 가져와서 태그 작성을 하려고 함
아직 게시글 작성하는 로직이 구현이 안돼서 테스트는 못해봤고 실행했을 때 오류 없이 실행되는 것은 확인했습니다.
그리고 tagCount를  추가했습니다. 이것은 삭제할 때나 나중에 검색할 때 이용하려고 합니다!