### PR TITLE
#61 리프레시 토큰 생성 및 #17 팔로우 내 예외처리 변경

### DIFF
--- a/src/main/java/com/paintourcolor/odle/config/WebSecurityConfig.java
+++ b/src/main/java/com/paintourcolor/odle/config/WebSecurityConfig.java
@@ -40,14 +40,13 @@ public class WebSecurityConfig implements WebMvcConfigurer {
         // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
-        http.authorizeRequests().antMatchers("/users/signup").permitAll()
+        http.authorizeRequests()
+                .antMatchers("/users/**").permitAll()
+                .antMatchers("/posts/**").permitAll()
                 .antMatchers(HttpMethod.OPTIONS, "/**").permitAll() // 프론트 CORS 오류 뜰 때
-                .antMatchers("/users/login").permitAll()
-                .antMatchers("/users/admin-signup").permitAll()
                 .anyRequest().authenticated()
                 // JWT 인증/인가를 사용하기 위한 설정
                 .and().addFilterBefore(new JwtAuthFilter(jwtUtil, logoutTokenRepository), UsernamePasswordAuthenticationFilter.class);
-
 
 //        http.formLogin().loginPage("/api/user/login-page").permitAll();
 //
@@ -58,7 +57,7 @@ public class WebSecurityConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedMethods("GET", "POST", "POST", "DELETE", "OPTIONS", "HEAD")
-                .exposedHeaders("Authorization");
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD");
+//                .exposedHeaders("Authorization");
     }
 }

--- a/src/main/java/com/paintourcolor/odle/controller/UserController.java
+++ b/src/main/java/com/paintourcolor/odle/controller/UserController.java
@@ -11,6 +11,7 @@ import com.paintourcolor.odle.service.*;
 import com.paintourcolor.odle.util.jwtutil.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,6 +29,7 @@ public class UserController {
     private final UserServiceInterface userService;
     private final AdminServiceInterface adminService;
     private final FollowServiceInterface followService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/signup")
     public String signUp(@RequestBody @Valid UserSignupRequest signUpRequest) {
@@ -51,10 +53,18 @@ public class UserController {
     // 유저, 관리자 로그아웃
     @PostMapping("/logout")
     public String logoutUser(HttpServletRequest request) {
-        String token = request.getHeader(JwtUtil.AUTHORIZATION_HEADER);
+        String token = jwtUtil.getRefreshToken(request);
         userService.logoutUser(token);
 //        return "redirect:/users/login";
         return "로그아웃 완료";
+    }
+
+    // AccessToken 재발급
+    @PostMapping("/reissue")
+    public ResponseEntity<String> reissueToken(HttpServletRequest httpServletRequest, HttpServletResponse response){
+        String refreshToken = jwtUtil.getRefreshToken(httpServletRequest);
+        userService.reissueToken(refreshToken, response);
+        return new ResponseEntity<>("토큰 재발급 완료",HttpStatus.OK);
     }
 
     @PostMapping("/{userId}/follow")

--- a/src/main/java/com/paintourcolor/odle/entity/Post.java
+++ b/src/main/java/com/paintourcolor/odle/entity/Post.java
@@ -48,7 +48,7 @@ public class Post extends Timestamped{
     }
 
     public Post(PostCreateRequest postCreateRequest, String username) {
-        this.music = postCreateRequest.getMusic();
+//        this.music = postCreateRequest.getMusic();
         this.content = postCreateRequest.getContent();
         this.openOrEnd = postCreateRequest.getOpenOrEnd();
         this.emotion = postCreateRequest.getEmotion();

--- a/src/main/java/com/paintourcolor/odle/entity/RefreshToken.java
+++ b/src/main/java/com/paintourcolor/odle/entity/RefreshToken.java
@@ -1,0 +1,17 @@
+package com.paintourcolor.odle.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshToken {
+    @Id
+    @Column(name = "refresh_token")
+    private String refreshToken;
+}

--- a/src/main/java/com/paintourcolor/odle/entity/User.java
+++ b/src/main/java/com/paintourcolor/odle/entity/User.java
@@ -2,6 +2,9 @@ package com.paintourcolor.odle.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
 
@@ -41,7 +44,15 @@ public class User {
         this.activation = activation;
     }
 
-    public boolean isActivation() {
-        return this.activation.equals(ActivationEnum.ACTIVE);
+    public void isActivation( ) {
+        if(!this.activation.equals(ActivationEnum.ACTIVE)) {
+            throw new DisabledException("비활성화 된 계정입니다.");
+        }
+    }
+
+    public void matchPassword(String requestPassword, PasswordEncoder passwordEncoder) {
+        if (!passwordEncoder.matches(requestPassword, this.password)){
+            throw new BadCredentialsException("아이디 혹은 비밀번호가 일치하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/paintourcolor/odle/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/paintourcolor/odle/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.paintourcolor.odle.repository;
+
+import com.paintourcolor.odle.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+}

--- a/src/main/java/com/paintourcolor/odle/service/UserServiceInterface.java
+++ b/src/main/java/com/paintourcolor/odle/service/UserServiceInterface.java
@@ -11,6 +11,7 @@ public interface UserServiceInterface {
     void signupUser(UserSignupRequest userSignupRequest);
     void loginUser(UserLoginRequest userLoginRequest, HttpServletResponse response);
     void logoutUser(String token);  // ?
+    void reissueToken(String refreshToken, HttpServletResponse response); //AccessToken 재발급
     void inactivateUser(String username, UserInactivateRequest userInactivateRequest); // 이거 리퀘스트 같이 써도 되는지,,,
     UserResponse getUser(int page);
 }

--- a/src/main/java/com/paintourcolor/odle/util/exception/RestApiExceptionHandler.java
+++ b/src/main/java/com/paintourcolor/odle/util/exception/RestApiExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.paintourcolor.odle.util.exception;
 
+import lombok.Builder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,4 +19,23 @@ public class RestApiExceptionHandler {
         return new ResponseEntity(restApiException, HttpStatus.BAD_REQUEST);
 
     }
+
+    @ExceptionHandler({UsernameNotFoundException.class})
+    public ResponseEntity UsernameNotFoundExceptionHandler(UsernameNotFoundException e) {
+        RestApiException restApiException = new RestApiException();
+        restApiException.setErrorCode("404");
+        restApiException.setHttpStatus(HttpStatus.NOT_FOUND);
+        restApiException.setErrorMessage(e.getMessage());
+        return new ResponseEntity(restApiException, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler({DisabledException.class})
+    public ResponseEntity DisabledExceptionHandler(DisabledException e) {
+        RestApiException restApiException = new RestApiException();
+        restApiException.setErrorCode("403");
+        restApiException.setHttpStatus(HttpStatus.FORBIDDEN);
+        restApiException.setErrorMessage(e.getMessage());
+        return new ResponseEntity(restApiException, HttpStatus.FORBIDDEN);
+    }
+
 }

--- a/src/main/java/com/paintourcolor/odle/util/jwtutil/JwtAuthFilter.java
+++ b/src/main/java/com/paintourcolor/odle/util/jwtutil/JwtAuthFilter.java
@@ -3,10 +3,12 @@ package com.paintourcolor.odle.util.jwtutil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.paintourcolor.odle.dto.security.SecurityExceptionDto;
 import com.paintourcolor.odle.repository.LogoutTokenRepository;
+import com.paintourcolor.odle.repository.RefreshTokenRepository;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,9 +31,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String token = jwtUtil.resolveToken(request);
+        String token = jwtUtil.getAccessToken(request);
+        String refreshToken = jwtUtil.getRefreshToken(request);
 
-        if(logoutTokenRepository.existsByToken(token)){
+        if(logoutTokenRepository.existsByToken(refreshToken)){
             throw new IllegalArgumentException("이미 로그아웃 처리된 토큰입니다");
         }
 
@@ -46,9 +49,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         filterChain.doFilter(request,response);
     }
 
-    public void setAuthentication(String username) {
+    public void setAuthentication(String email) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
-        Authentication authentication = jwtUtil.createAuthentication(username);
+        Authentication authentication = jwtUtil.createAuthentication(email);
         context.setAuthentication(authentication);
 
         SecurityContextHolder.setContext(context);


### PR DESCRIPTION
WebSecurityConfig : url 별 권한 통합
Post: 미구현된 메서드 주석처리
User: 활성화 및 비밀번호 확인 메서드 추가

#61
UserController: reissue 추가 및 로그아웃 시 리프레시 토큰을 받아오도록 변경
UserServiceInterface: reissue 추가
UserService: reissue 추가 및 login 시 리프레시 토큰 발급 추가.
JwtAuthFilter: 리프레시토큰도 함께 받아오도록 추가
JwtUtil: 리프레시토큰 추가
RefreshToken, Refresh TokenRepository: 신규 생성

#17 
FollowService: Exception 변경
RestApiExceptionHandler: UsernameNotFouondException 및 EsabledException 추가

비활성화 유저 확인 등 예외처리가 부족하여 추가하도록 하겠습니다