### PR TITLE
#48 fix : getMusic 노래 정보 조회 기능 수정 완료

### DIFF
--- a/src/main/java/com/paintourcolor/odle/controller/MusicController.java
+++ b/src/main/java/com/paintourcolor/odle/controller/MusicController.java
@@ -1,4 +1,21 @@
 package com.paintourcolor.odle.controller;
 
+import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
+import com.paintourcolor.odle.service.MusicServiceInterface;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/music")
 public class MusicController {
+    private final MusicServiceInterface musicService;
+    // 노래 정보 조회
+    @GetMapping("/{musicId}")
+    public MusicResponse getMusic(@PathVariable Long musicId) {
+        return musicService.getMusic(musicId);
+    }
 }

--- a/src/main/java/com/paintourcolor/odle/controller/MusicController.java
+++ b/src/main/java/com/paintourcolor/odle/controller/MusicController.java
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class MusicController {
     private final MusicServiceInterface musicService;
     // 노래 정보 조회
-    @GetMapping("/{musicId}")
-    public MusicResponse getMusic(@PathVariable Long musicId) {
-        return musicService.getMusic(musicId);
+    @GetMapping("/{melonId}")
+    public MusicResponse getMusic(@PathVariable Long melonId) {
+        return musicService.getMusic(melonId);
     }
 }

--- a/src/main/java/com/paintourcolor/odle/dto/mucis/response/MusicResponse.java
+++ b/src/main/java/com/paintourcolor/odle/dto/mucis/response/MusicResponse.java
@@ -1,4 +1,16 @@
 package com.paintourcolor.odle.dto.mucis.response;
 
+import lombok.Getter;
+
+@Getter
 public class MusicResponse {
+    private String title;
+    private String singer;
+    private String cover;
+
+    public MusicResponse(String title, String singer, String cover) {
+        this.title = title;
+        this.singer = singer;
+        this.cover = cover;
+    }
 }

--- a/src/main/java/com/paintourcolor/odle/entity/MelonKorea.java
+++ b/src/main/java/com/paintourcolor/odle/entity/MelonKorea.java
@@ -1,0 +1,21 @@
+package com.paintourcolor.odle.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class MelonKorea {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String title;
+    @Column(nullable = false)
+    private String singer;
+    @Column(nullable = false)
+    private String cover;
+}

--- a/src/main/java/com/paintourcolor/odle/entity/Post.java
+++ b/src/main/java/com/paintourcolor/odle/entity/Post.java
@@ -19,12 +19,12 @@ public class Post extends Timestamped{
     @ManyToOne
     @JoinColumn(name = "userId", nullable = false)
     private User user;
-
-
-
     @ManyToOne
     @JoinColumn(name = "musicId", nullable = false)
     private Music music;
+    @ManyToOne
+    @JoinColumn(name = "melonKoreaId", nullable = false)
+    private MelonKorea melonKorea;
     @Column(nullable = false)
     private Long likeCount;
     private String content;

--- a/src/main/java/com/paintourcolor/odle/repository/MelonKoreaRepository.java
+++ b/src/main/java/com/paintourcolor/odle/repository/MelonKoreaRepository.java
@@ -1,0 +1,7 @@
+package com.paintourcolor.odle.repository;
+
+import com.paintourcolor.odle.entity.MelonKorea;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MelonKoreaRepository extends JpaRepository<MelonKorea, Long> {
+}

--- a/src/main/java/com/paintourcolor/odle/service/MusicService.java
+++ b/src/main/java/com/paintourcolor/odle/service/MusicService.java
@@ -1,22 +1,22 @@
 package com.paintourcolor.odle.service;
 
 import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
-import com.paintourcolor.odle.entity.Music;
-import com.paintourcolor.odle.repository.MusicRepository;
+import com.paintourcolor.odle.entity.MelonKorea;
+import com.paintourcolor.odle.repository.MelonKoreaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MusicService implements MusicServiceInterface {
-    private final MusicRepository musicRepository;
+    private final MelonKoreaRepository melonRepository;
     // 노래 정보 조회
     @Override
-    public MusicResponse getMusic(Long musicId) {
-        Music music = musicRepository.findById(musicId).orElseThrow(
+    public MusicResponse getMusic(Long melonId) {
+        MelonKorea melon = melonRepository.findById(melonId).orElseThrow(
                 () -> new IllegalArgumentException("존재하지 않는 음악입니다.")
         );
 
-        return new MusicResponse(music.getTitle(), music.getSinger(), music.getCover());
+        return new MusicResponse(melon.getTitle(), melon.getSinger(), melon.getCover());
     }
 }

--- a/src/main/java/com/paintourcolor/odle/service/MusicService.java
+++ b/src/main/java/com/paintourcolor/odle/service/MusicService.java
@@ -1,11 +1,22 @@
 package com.paintourcolor.odle.service;
 
 import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
+import com.paintourcolor.odle.entity.Music;
+import com.paintourcolor.odle.repository.MusicRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
-public class MusicService implements MusicServiceInterface{
+@Service
+@RequiredArgsConstructor
+public class MusicService implements MusicServiceInterface {
+    private final MusicRepository musicRepository;
     // 노래 정보 조회
     @Override
     public MusicResponse getMusic(Long musicId) {
-        return null;
+        Music music = musicRepository.findById(musicId).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 음악입니다.")
+        );
+
+        return new MusicResponse(music.getTitle(), music.getSinger(), music.getCover());
     }
 }


### PR DESCRIPTION
노래 정보를 찾아오는 곳을 musicRepository -> melonKoreaRepository로 수정
Melon 관련 엔티티, 레퍼지토리 추가
테이블을 추가해서 쿼리문은 슬렉으로 공유드리겠습니다.

MusicController
MelonKorea
Post
MelonKoreaRepository
MusicService