### PR TITLE
#114 feat: getMusicSearchList 추가

### DIFF
--- a/src/main/java/com/paintourcolor/odle/controller/MusicController.java
+++ b/src/main/java/com/paintourcolor/odle/controller/MusicController.java
@@ -1,24 +1,42 @@
 package com.paintourcolor.odle.controller;
 
 import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
+import com.paintourcolor.odle.dto.mucis.response.MusicSearchResponse;
 import com.paintourcolor.odle.service.MusicServiceInterface;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/music")
 public class MusicController {
     private final MusicServiceInterface musicService;
+
     // 노래 정보 조회
     @GetMapping("/{melonId}")
     public ResponseEntity<MusicResponse> getMusic(@PathVariable Long melonId) {
         MusicResponse musicResponse = musicService.getMusic(melonId);
         return new ResponseEntity<>(musicResponse, HttpStatus.OK);
     }
+
+    //Param으로 option 및 keyword 가져옴
+    //option: 제목, 가수
+    //keyword: 입력한 키워드를 포함하는 모든 음악 리스트를 가져옴
+    //페이지 기본 설정: 음악 수-10, 첫페이지-1(index:0)
+    //(정렬을 최신순으로 하고 싶었으나, 크롤링 시 한번에 가져온 데이터는 정렬이 불가할 것 같음)
+    @GetMapping("/search")
+    public ResponseEntity<List<MusicSearchResponse>> getMusicSearchList(Pageable pageable,
+                                                                  @RequestParam(value = "option") String option,
+                                                                  @RequestParam(value = "keyword") String keyword) {
+        List<MusicSearchResponse> musicSearchList = musicService.getMusicSearchList(pageable, option, keyword);
+        return new ResponseEntity<>(musicSearchList, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/paintourcolor/odle/dto/mucis/response/MusicSearchResponse.java
+++ b/src/main/java/com/paintourcolor/odle/dto/mucis/response/MusicSearchResponse.java
@@ -1,0 +1,21 @@
+package com.paintourcolor.odle.dto.mucis.response;
+
+import com.paintourcolor.odle.entity.MelonKorea;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MusicSearchResponse {
+    Long melonMusicId;
+    String title;
+    String singer;
+    String cover;
+
+    public MusicSearchResponse(MelonKorea melonKorea) {
+        this.melonMusicId = melonKorea.getId();
+        this.title = melonKorea.getTitle();
+        this.singer = melonKorea.getSinger();
+        this.cover = melonKorea.getCover();
+    }
+}

--- a/src/main/java/com/paintourcolor/odle/repository/MelonKoreaRepository.java
+++ b/src/main/java/com/paintourcolor/odle/repository/MelonKoreaRepository.java
@@ -1,7 +1,13 @@
 package com.paintourcolor.odle.repository;
 
 import com.paintourcolor.odle.entity.MelonKorea;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MelonKoreaRepository extends JpaRepository<MelonKorea, Long> {
+    List<MelonKorea> findAllByTitleContainsIgnoreCase(Pageable pageable, String keyword);
+    List<MelonKorea> findAllBySingerContainsIgnoreCase(Pageable pageable, String keyword);
+
 }

--- a/src/main/java/com/paintourcolor/odle/service/MusicService.java
+++ b/src/main/java/com/paintourcolor/odle/service/MusicService.java
@@ -1,11 +1,20 @@
 package com.paintourcolor.odle.service;
 
 import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
+import com.paintourcolor.odle.dto.mucis.response.MusicSearchResponse;
 import com.paintourcolor.odle.entity.MelonKorea;
 import com.paintourcolor.odle.repository.MelonKoreaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,4 +30,27 @@ public class MusicService implements MusicServiceInterface {
 
         return new MusicResponse(melon.getId(), melon.getTitle(), melon.getSinger(), melon.getCover());
     }
+
+    @Transactional
+    @Override
+    public List<MusicSearchResponse> getMusicSearchList(Pageable pageable, String searchOption, String keyword) {
+            if(keyword.isEmpty()){
+                throw new IllegalArgumentException("키워드 누락");
+            }
+
+            List<MelonKorea> musicSearchList = switch (searchOption) {
+                case "제목" -> melonRepository.findAllByTitleContainsIgnoreCase(pageable, keyword);
+                case "가수" -> melonRepository.findAllBySingerContainsIgnoreCase(pageable,keyword);
+                default -> throw new IllegalArgumentException("옵션 누락");
+            };
+
+        if(musicSearchList.isEmpty()){
+            throw new IllegalArgumentException("검색 결과가 없습니다");
+        }
+
+        return musicSearchList.stream()
+                .map(MusicSearchResponse::new)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/paintourcolor/odle/service/MusicServiceInterface.java
+++ b/src/main/java/com/paintourcolor/odle/service/MusicServiceInterface.java
@@ -1,10 +1,15 @@
 package com.paintourcolor.odle.service;
 
 import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
+import com.paintourcolor.odle.dto.mucis.response.MusicSearchResponse;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface MusicServiceInterface {
     // 노래 정보 조회
     MusicResponse getMusic(Long musicId);
+    List<MusicSearchResponse> getMusicSearchList(Pageable pageable, String searchOption, String keyword);
 //    // 감정에 대한 TOP 포스팅 노래 리스트 조회(추가기능)
 //    EmotionChartResponse getEmotionChart(EmotionChartRequest emotionChartRequest, int page);
 //    // 오늘 가장 많이 포스팅된 TOP 노래 리스트 조회(추가기능)


### PR DESCRIPTION
#114  feat: getMusicSearchList 추가

1. MusicController
2. MusicService
3. MusicServiceInterface
4. MusicSearchResponse
5. MusicRepository

keyword 및 option 을 Param으로 넘겨받는 걸로 구현했습니다.

제목 및 가수 옵션 중 하나만 선택 가능하고,
입력된 keyword와 정확히 일치하는 단어를 포함하는 경우만 반환 합니다.

JPARepository 기능 이용해서 만들었고, 전체 검색이나 여러 키워드 검색은 성능면으로 아직 고려하지 못하여 간단한 기능만 구현하였습니다.