### PR TITLE
#100 fix : logout() 로그아웃 시 AccessToken 제거

### DIFF
--- a/src/main/resources/static/js/logout.js
+++ b/src/main/resources/static/js/logout.js
@@ -1,23 +1,23 @@
-
 function logOut() {
-const accessToken = localStorage.getItem('accessToken');
-const refreshToken = getCookie('RefreshToken');
-const settings = {
-    "url": "http://localhost:8080/users/logout",
-    "method": "POST",
-    "timeout": 0,
-    "headers": {
-        "RefreshToken": refreshToken,
-        "Authorization": accessToken
-    }
-    
+    const accessToken = localStorage.getItem('accessToken');
+    const refreshToken = getCookie('RefreshToken');
+    const settings = {
+        "url": "http://localhost:8080/users/logout",
+        "method": "POST",
+        "timeout": 0,
+        "headers": {
+            "RefreshToken": refreshToken,
+            "Authorization": accessToken
+        }
+
     };
-    
+
     $.ajax(settings)
-    .done(function (response) {
-    console.log(response);
-    window.location = 'signin.html'
-    });
+        .done(function (response) {
+            localStorage.setItem('accessToken', '');
+            console.log(response);
+            window.location = 'signin.html'
+        });
 }
 
 function getCookie(name) {


### PR DESCRIPTION
로그아웃 눌렀을 때 AccessToken에 빈 문자열로 덮어씌우게 구현
17줄에 한줄 추가된거고 나머지는 그냥 들여쓰기 수정된거에요
logout.js