### PR TITLE
#139 feat: Front 연결 - 관리자 유저 활성화/비활성화 페이지 및 Security/UserController 변경

### DIFF
--- a/src/main/java/com/paintourcolor/odle/config/WebSecurityConfig.java
+++ b/src/main/java/com/paintourcolor/odle/config/WebSecurityConfig.java
@@ -35,7 +35,8 @@ public class WebSecurityConfig implements WebMvcConfigurer {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf().disable();
+        http.csrf().disable()
+                .cors();//CORS 설정 추가
 
         // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
@@ -44,7 +45,7 @@ public class WebSecurityConfig implements WebMvcConfigurer {
                 .antMatchers("/**/admin").hasRole("ADMIN")
                 .antMatchers("/users/**").permitAll()
                 .antMatchers("/posts/**").permitAll()
-                .antMatchers(HttpMethod.OPTIONS, "/**").permitAll() // 프론트 CORS 오류 뜰 때
+//                .antMatchers(HttpMethod.OPTIONS, "/**").permitAll() // 프론트 CORS 오류 뜰 때
                 .anyRequest().authenticated()
                 // JWT 인증/인가를 사용하기 위한 설정
                 .and().addFilterBefore(new JwtAuthFilter(jwtUtil, logoutTokenRepository), UsernamePasswordAuthenticationFilter.class);
@@ -55,6 +56,7 @@ public class WebSecurityConfig implements WebMvcConfigurer {
 
         return http.build();
     }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")

--- a/src/main/java/com/paintourcolor/odle/controller/UserController.java
+++ b/src/main/java/com/paintourcolor/odle/controller/UserController.java
@@ -91,7 +91,7 @@ public class UserController {
     //ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ로그인 및 회원가입 외 유저 기능 여기서부터ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ//
     // 관리자가 유저 목록 조회
     @GetMapping("")
-    public ResponseEntity<List<UserResponse>> getUsers(@PageableDefault(sort = "userId",direction = Sort.Direction.DESC) Pageable pageable,
+    public ResponseEntity<List<UserResponse>> getUsers(@PageableDefault(sort = "id") Pageable pageable,
                                                  @AuthenticationPrincipal UserDetailsImpl userDetails){
         List<UserResponse> userList = userService.getUsers(pageable);
         return new ResponseEntity<>(userList,HttpStatus.OK);
@@ -99,7 +99,7 @@ public class UserController {
 
     // 내 프로필에서 내 게시글들 목록 조회
     @GetMapping("/{userId}/profile/posts")
-    public ResponseEntity<List<ProfilePostResponse>> getProfilePosts(@PageableDefault(sort = "createdAt",direction = Sort.Direction.ASC) Pageable pageable,
+    public ResponseEntity<List<ProfilePostResponse>> getProfilePosts(@PageableDefault(sort = "id",direction = Sort.Direction.DESC) Pageable pageable,
                                                                      @PathVariable Long userId,
                                                                      @AuthenticationPrincipal UserDetailsImpl userDetails){
         List<ProfilePostResponse> profilePostList = userService.getProfilePosts(userId, pageable);
@@ -183,7 +183,7 @@ public class UserController {
     @DeleteMapping("/{userId}/unfollow")
     public ResponseEntity<StatusResponse> unfollowUser(@PathVariable Long userId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         followService.unfollowUser(userDetails.getUserId(), userId);
-        return new ResponseEntity<>(new StatusResponse(HttpStatus.OK.value(),"팔로우 완료"), HttpStatus.OK);
+        return new ResponseEntity<>(new StatusResponse(HttpStatus.OK.value(),"언팔로우 완료"), HttpStatus.OK);
     }
 
     // 팔로워 목록 조회

--- a/src/main/java/com/paintourcolor/odle/dto/user/response/UserResponse.java
+++ b/src/main/java/com/paintourcolor/odle/dto/user/response/UserResponse.java
@@ -1,5 +1,6 @@
 package com.paintourcolor.odle.dto.user.response;
 
+import com.paintourcolor.odle.entity.ActivationEnum;
 import com.paintourcolor.odle.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,14 +11,12 @@ public class UserResponse {
     Long userId;
     String email;
     String username;
-    String profileImage;
-    String introduction;
+    ActivationEnum activation;
 
     public UserResponse(User user) {
         this.userId = user.getId();
         this.email = user.getEmail();
         this.username = user.getUsername();
-        this.profileImage = user.getProfileImage();
-        this.introduction = user.getIntroduction();
+        this.activation = user.getActivation();
     }
 }

--- a/src/main/java/com/paintourcolor/odle/entity/User.java
+++ b/src/main/java/com/paintourcolor/odle/entity/User.java
@@ -64,13 +64,13 @@ public class User {
 
     public void isInactivation( ) {
         if(!this.activation.equals(ActivationEnum.INACTIVE)) {
-            throw new DisabledException("활성화 된 계정입니다.");
+            throw new IllegalArgumentException("활성화 된 계정입니다.");
         }
     }
 
     public void matchPassword(String requestPassword, PasswordEncoder passwordEncoder) {
         if (!passwordEncoder.matches(requestPassword, this.password)){
-            throw new BadCredentialsException("아이디 혹은 비밀번호가 일치하지 않습니다.");
+            throw new BadCredentialsException("계정 혹은 비밀번호를 재확인 바랍니다.");
         }
     }
 

--- a/src/main/java/com/paintourcolor/odle/util/exception/RestApiExceptionHandler.java
+++ b/src/main/java/com/paintourcolor/odle/util/exception/RestApiExceptionHandler.java
@@ -3,6 +3,7 @@ package com.paintourcolor.odle.util.exception;
 import lombok.Builder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -46,5 +47,14 @@ public class RestApiExceptionHandler {
         restApiException.setHttpStatus(HttpStatus.BAD_REQUEST);
         restApiException.setErrorMessage(e.getBindingResult().getFieldError().getDefaultMessage());
         return new ResponseEntity(restApiException, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler({BadCredentialsException.class})
+    public ResponseEntity BadCredentialsException(BadCredentialsException e) {
+        RestApiException restApiException = new RestApiException();
+        restApiException.setErrorCode("401");
+        restApiException.setHttpStatus(HttpStatus.UNAUTHORIZED);
+        restApiException.setErrorMessage(e.getMessage());
+        return new ResponseEntity(restApiException, HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/resources/static/js/admin.js
+++ b/src/main/resources/static/js/admin.js
@@ -1,0 +1,90 @@
+const api_url = "http://localhost:8080/users/"; //공통 Url
+
+$(document).ready(function () {
+    getUserList() //유저 목록 가져오기
+});
+
+// 유저 목록 가져오기
+function getUserList() {
+    $.ajax({
+        url: api_url,
+        type: "GET",
+        contentType: "json",
+        success: function (response) {
+            $('#user_card_list').empty(); // 유저 틀 초기화
+
+            for (let i = 0; i < response.length; i++) {
+            const userId = response[i]['userId'] // 유저 이름
+            const username = response[i]['username'] // 유저 이름
+            const email = response[i]['email'] //유저 이메일
+            let activation = response[i]['activation'] //활성화 여부
+
+            const user_temp = `
+            <div id="user_card">
+            <span>유저 아이디: </span><span id="user_id">${userId}</span>
+            <span>유저 이메일: </span><span id="user_email">${email}</span>
+            <span>유저 이름: </span><span id="user_username">${username}</span>
+            <span>활성화 여부: </span><span id="user_activation_${userId}">${activation}</span>
+            <button id="user_active" onclick = "activateUser(${userId})">활성화</button>
+            <button id="user_inactive" onclick = "inactivateUser(${userId})">비활성화</button>
+            </div>
+            `
+            $('#user_card_list').append(user_temp)
+        }
+        }
+    });
+}
+
+//유저 활성화
+function activateUser(userId) {
+    $.ajax({
+        url: api_url + userId + "/activation/admin",
+        type: "PATCH",
+        contentType: "application/json; charset=UTF-8",
+        headers: {
+            "Authorization": localStorage.getItem("accessToken")
+        },
+        data: JSON.stringify({
+            "password": $('#admin_password').val()
+        }),
+        success: function (response) {
+            $('#user_activation_'+ userId).text("ACTIVE")
+        },
+        error: function (response) {
+            const errorMessage = response.responseJSON['errorMessage']
+            if(errorMessage){
+                alert(errorMessage);
+            } else{
+                alert("에러: "+ response.status)
+            }
+        }
+    });
+}
+
+//유저 비활성화
+function inactivateUser(userId) {
+    $.ajax({
+        url: api_url + userId + "/inactivation/admin",
+        type: "PATCH",
+        contentType: "application/json; charset=UTF-8",
+        headers: {
+            "Authorization": localStorage.getItem("accessToken")
+        },
+        data: JSON.stringify({
+            "password": $('#admin_password').val()
+        }),
+        success: function (response) {
+            $('#user_activation_'+ userId).text("INACTIVE")
+        },
+        error: function (response) {
+            const errorMessage = response.responseJSON['errorMessage']
+            if(errorMessage){
+                alert(errorMessage);
+            } else{
+                alert("에러: "+ response.status)
+            }
+        }
+    });
+}
+
+

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ko">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin 메인 페이지</title>
+        <!-- JQuery 사용 설정 -->
+    <script src="http://code.jquery.com/jquery-latest.js"></script>
+</head>
+
+<body>
+    <header>
+        <h1>관리자 페이지 입니다. (유저 활성/비활성)</h1>
+        <h3><a href="./admin_feed.html">관리자 페이지 - 게시글 삭제 가기<a></a></h3>
+    </header>
+    <div class="input_field">
+        <input type="text" id="admin_password" placeholder="비밀번호를 입력하세요" class="input">
+    </div>
+     <div id="user_card_list">
+        <div id="user_card">
+            <span>유저 아이디: </span><span id="user_id"></span>
+            <span>유저 이메일: </span><span id="user_email"></span>
+            <span>유저 이름: </span><span id="user_username"></span>
+            <span>활성화 여부: </span><span id="user_activation"></span>
+            <button id="user_active">활성화</button>
+            <button id="user_inactive">비활성화</button>
+        </div>
+    </div>
+        <script src="../static/js/admin.js"></script>
+</body>
+</html>


### PR DESCRIPTION
#139 feat: Front 연결 - 관리자 유저 활성화/비활성화 페이지
1) UserResponse
- profileImage 및 introduction 제외 및 activation 반환하도록 변경
2) User
- isInactivation 예외 변경 및 BadCredential 메세지 변경
3) RestApiExceptionHandler: BadCredentialException 추가
- admin.js / admin.html: 관리자의 유저 활성화/비활성화 추가

#2 fix: CORS 설정 변경
1) WebSecurityConfig:
- 프론트 연결시 CORS 에러가 많이 나서 Security쪽에서 기존 설정에 충돌 없이 자동으로 CORS 설정하도록 코드 변경하였습니다.
 
fix: getProfilePosts, getUsers 인덱싱 수정 및 unfollowUser 완료 메세지 수정
- UserController: 상동