### PR TITLE
#122 #146 fix: 게시글 노래검색 누르면 결과 쌓이는 현상 수정, 게시글 노래 정렬, db 중복제거, feat: 스케줄러

### DIFF
--- a/src/main/java/com/paintourcolor/odle/OdleApplication.java
+++ b/src/main/java/com/paintourcolor/odle/OdleApplication.java
@@ -3,8 +3,10 @@ package com.paintourcolor.odle;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class OdleApplication {
 

--- a/src/main/java/com/paintourcolor/odle/config/WebSecurityConfig.java
+++ b/src/main/java/com/paintourcolor/odle/config/WebSecurityConfig.java
@@ -45,7 +45,7 @@ public class WebSecurityConfig implements WebMvcConfigurer {
                 .antMatchers("/**/admin").hasRole("ADMIN")
                 .antMatchers("/users/**").permitAll()
                 .antMatchers("/posts/**").permitAll()
-                .antMatchers("/crawl").permitAll()
+                .antMatchers("/crawl/**").permitAll()
 //                .antMatchers(HttpMethod.OPTIONS, "/**").permitAll() // 프론트 CORS 오류 뜰 때
                 .anyRequest().authenticated()
                 // JWT 인증/인가를 사용하기 위한 설정

--- a/src/main/java/com/paintourcolor/odle/crawl/MelonController.java
+++ b/src/main/java/com/paintourcolor/odle/crawl/MelonController.java
@@ -1,16 +1,20 @@
 package com.paintourcolor.odle.crawl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/crawl")
 public class MelonController {
     private final MelonMapper melonMapper;
 
-    //국내 차트 크롤링
-    @GetMapping("/crawl/korea")
+    //2시간마다 국내 차트 크롤링
+    //@Scheduled(fixedRate = 60 * 1000 * 60 * 2)
+    @GetMapping("/korea")
     public void crawlKoreaMelon() {
         MelonCrawler melonCrawler = new MelonCrawler(melonMapper);
 
@@ -19,7 +23,7 @@ public class MelonController {
     }
 
     //해외 차트 크롤링
-    @GetMapping("/crawl/global")
+    @GetMapping("/global")
     public void crawlGlobalMelon() {
         MelonCrawler melonCrawler = new MelonCrawler(melonMapper);
 

--- a/src/main/resources/mapper/MelonMapper.xml
+++ b/src/main/resources/mapper/MelonMapper.xml
@@ -5,11 +5,12 @@
 
 <mapper namespace="com.paintourcolor.odle.crawl.MelonMapper">
 
-    <insert id="insert" useGeneratedKeys="true"> ##parameterType="com.paintourcolor.odle.entity.MelonKorea"
-        insert into odle.melon_korea (title, singer, cover)
-        values(#{title}, #{singer}, #{cover})
+    <insert id="insert" useGeneratedKeys="true">
+        <!--insert into odle.melon_korea (title, singer, cover)-->
+        <!--values(#{title}, #{singer}, #{cover})-->
+        INSERT INTO odle.melon_korea (title, singer, cover) SELECT #{title}, #{singer}, #{cover} FROM DUAL WHERE NOT EXISTS
+        (SELECT * FROM odle.melon_korea WHERE id > 300 AND title = #{title} AND singer = #{singer} AND cover = #{cover});
     </insert>
-
 <!--    <insert id="insert" useGeneratedKeys="true"> ##parameterType="com.paintourcolor.odle.entity.MelonGlobal"-->
 <!--    insert into odle.melon_global (title, singer, cover)-->
 <!--    values(#{title}, #{singer}, #{cover})-->

--- a/src/main/resources/static/css/post.css
+++ b/src/main/resources/static/css/post.css
@@ -88,3 +88,11 @@ input {
   width: 20%;
   margin-left: 75%;
 }
+
+.music-info {
+  display : flex;
+
+  justify-content: center;
+
+  align-items : center;
+}

--- a/src/main/resources/static/js/post_create.js
+++ b/src/main/resources/static/js/post_create.js
@@ -69,6 +69,7 @@ function getMusicSearchList() {
     };
 
     $.ajax(settings).done(function (response) {
+        $("#searched-music-list").empty()
         for (let i = 0; i < response.length; i++) {
             const melonMusicId = response[i]['melonMusicId']
             const title = response[i]['title']

--- a/src/main/resources/templates/post.html
+++ b/src/main/resources/templates/post.html
@@ -30,7 +30,7 @@
         <div class="photo__header" id="getMySimpleProfile">
             <div>
                 <a id="myProfile_post_pic" role="link" tabindex="0">
-                    <img alt="프로필 사진" src="" id="myProfileImage" class="photo__avatar" />
+                    <img alt="프로필 사진" src="" id="myProfileImage" class="photo__avatar"/>
                 </a>
             </div>
             <div class="photo__user-info">
@@ -120,16 +120,21 @@
             <div class="window">
                 <div class="popup">
                     <div class="btn-group" role="group" aria-label="Basic radio toggle button group">
-                        <input type="radio" class="btn-check" name="music-search" value="가수" id="singer-post" autocomplete="off"
+                        <input type="radio" class="btn-check" name="music-search" value="가수" id="singer-post"
+                               autocomplete="off"
                                checked>
                         <label class="btn btn-outline-primary" for="singer-post">가수</label>
 
-                        <input type="radio" class="btn-check" name="music-search" value="제목" id="title-post" autocomplete="off">
+                        <input type="radio" class="btn-check" name="music-search" value="제목" id="title-post"
+                               autocomplete="off">
                         <label class="btn btn-outline-primary" for="title-post">제목</label>
                     </div>
                     <div class="input-group mb-3">
-                        <input id="music-keyword" type="text" class="form-control" placeholder="입력해주세요" aria-label="입력해주세요" aria-describedby="button-addon2">
-                        <button class="btn btn-outline-secondary" type="button" id="button-addon2" onclick="getMusicSearchList()">검색</button>
+                        <input id="music-keyword" type="text" class="form-control" placeholder="입력해주세요"
+                               aria-label="입력해주세요" aria-describedby="button-addon2">
+                        <button class="btn btn-outline-secondary" type="button" id="button-addon2"
+                                onclick="getMusicSearchList()">검색
+                        </button>
                     </div>
                     <div id="searched-music-list">
                     </div>
@@ -147,15 +152,18 @@
             <label class="btn btn-outline-primary" for="btnradio2">닫는 노래</label>
         </div>
     </div>
-    <div id="music-info">
-        <div id="post-melon-id" >멜론아이디</div>
-        <div id="post-title">제목</div>
-        <div id="post-singer">가수</div>
-        <img id="post-cover" src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSlQ_lwqhefUx9tX5xxqH-ZZ9SOZO7YunrwOA&usqp=CAU">
+    <div id="music-info" class="music-info">
+        <div>
+            <div id="post-melon-id">멜론아이디</div>
+            <div id="post-title">제목</div>
+            <div id="post-singer">가수</div>
+            <img id="post-cover"
+                 src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSlQ_lwqhefUx9tX5xxqH-ZZ9SOZO7YunrwOA&usqp=CAU">
+        </div>
     </div>
 
     <div class="input-group">
-        <span class="input-group-text" >게시글작성</span>
+        <span class="input-group-text">게시글작성</span>
         <textarea aria-label="With textarea" class="form-control h-25" id="content" rows="10"></textarea>
     </div>
     <div class="input-group mb-3">


### PR DESCRIPTION
WebSecurityConfig.java
MelonController.java
OdleApplication,java
MelonMapper.java
post.css
post_create.js
post.html

검색을 누르면 결과가 밑에 계속 쌓이던 현상 수정.
게시글 작성란에 노래 정보 가운데 정렬.
첫 페이지 크롤링해서 올릴 때 중복 제거해서 올리는 기능 추가.
두시간마다 크롤링 해오는 스케줄러 작성(멜론 컨트롤러에 주석처리 해둠).