### PR TITLE
#49 fix : getEmotionChart 감정 차트에 대한 조회 코드 간소화, #30 fix : LinkedHashSet을 HashSet으로 변경

### DIFF
--- a/src/main/java/com/paintourcolor/odle/controller/MusicController.java
+++ b/src/main/java/com/paintourcolor/odle/controller/MusicController.java
@@ -3,6 +3,7 @@ package com.paintourcolor.odle.controller;
 import com.paintourcolor.odle.dto.mucis.response.MusicChartResponse;
 import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
 import com.paintourcolor.odle.dto.mucis.response.MusicSearchResponse;
+import com.paintourcolor.odle.entity.EmotionEnum;
 import com.paintourcolor.odle.service.MusicServiceInterface;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -38,52 +39,10 @@ public class MusicController {
         return new ResponseEntity<>(musicSearchList, HttpStatus.OK);
     }
 
-    // angry 차트 조회
-    @GetMapping("/charts/angry")
-    public ResponseEntity<List<MusicChartResponse>> getAngryChart() {
-        List<MusicChartResponse> musicChartResponses = musicService.getAngryChart();
-        return new ResponseEntity<>(musicChartResponses, HttpStatus.OK);
-    }
-
-    // sad 차트 조회
-    @GetMapping("/charts/sad")
-    public ResponseEntity<List<MusicChartResponse>> getSadChart() {
-        List<MusicChartResponse> musicChartResponses = musicService.getSadChart();
-        return new ResponseEntity<>(musicChartResponses, HttpStatus.OK);
-    }
-
-    // scream 차트 조회
-    @GetMapping("/charts/scream")
-    public ResponseEntity<List<MusicChartResponse>> getScreamChart() {
-        List<MusicChartResponse> musicChartResponses = musicService.getScreamChart();
-        return new ResponseEntity<>(musicChartResponses, HttpStatus.OK);
-    }
-
-    // shy 차트 조회
-    @GetMapping("/charts/shy")
-    public ResponseEntity<List<MusicChartResponse>> getShyChart() {
-        List<MusicChartResponse> musicChartResponses = musicService.getShyChart();
-        return new ResponseEntity<>(musicChartResponses, HttpStatus.OK);
-    }
-
-    // happy 차트 조회
-    @GetMapping("/charts/happy")
-    public ResponseEntity<List<MusicChartResponse>> getHappyChart() {
-        List<MusicChartResponse> musicChartResponses = musicService.getHappyChart();
-        return new ResponseEntity<>(musicChartResponses, HttpStatus.OK);
-    }
-
-    // love 차트 조회
-    @GetMapping("/charts/love")
-    public ResponseEntity<List<MusicChartResponse>> getLoveChart() {
-        List<MusicChartResponse> musicChartResponses = musicService.getLoveChart();
-        return new ResponseEntity<>(musicChartResponses, HttpStatus.OK);
-    }
-
-    // flex 차트 조회
-    @GetMapping("/charts/flex")
-    public ResponseEntity<List<MusicChartResponse>> getFlexChart() {
-        List<MusicChartResponse> musicChartResponses = musicService.getFlexChart();
+    // 감정 차트 조회
+    @GetMapping("/charts/{emotion}")
+    public ResponseEntity<List<MusicChartResponse>> getEmotionChart(@PathVariable EmotionEnum emotion) {
+        List<MusicChartResponse> musicChartResponses = musicService.getEmotionChart(emotion);
         return new ResponseEntity<>(musicChartResponses, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/paintourcolor/odle/entity/Post.java
+++ b/src/main/java/com/paintourcolor/odle/entity/Post.java
@@ -5,7 +5,6 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 @Getter
@@ -36,7 +35,7 @@ public class Post extends Timestamped{
     private Long commentCount;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<PostTag> postTags = new LinkedHashSet<>();
+    private Set<PostTag> postTags = new HashSet<>();
 
     public void plusComment() {
         this.commentCount += 1;

--- a/src/main/java/com/paintourcolor/odle/repository/PostRepository.java
+++ b/src/main/java/com/paintourcolor/odle/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.paintourcolor.odle.repository;
 
+import com.paintourcolor.odle.entity.EmotionEnum;
 import com.paintourcolor.odle.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,63 +23,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT m.id, m.title, m.singer, m.cover, COUNT(p.music.id) AS musicCount " +
             "FROM Music m " +
             "LEFT JOIN m.posts p " +
-            "WHERE p.emotion = 'angry' " +
+            "WHERE p.emotion = :emotion " +
             "AND p.createdAt BETWEEN :startDate AND :endDate " +
             "GROUP BY m.id " +
             "ORDER BY musicCount DESC")
-    List<Object[]> findAngryMusicIdsWithCountAndMusicInfo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
-
-    @Query("SELECT m.id, m.title, m.singer, m.cover, COUNT(p.music.id) AS musicCount " +
-            "FROM Music m " +
-            "LEFT JOIN m.posts p " +
-            "WHERE p.emotion = 'sad' " +
-            "AND p.createdAt BETWEEN :startDate AND :endDate " +
-            "GROUP BY m.id " +
-            "ORDER BY musicCount DESC")
-    List<Object[]> findSadMusicIdsWithCountAndMusicInfo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
-
-    @Query("SELECT m.id, m.title, m.singer, m.cover, COUNT(p.music.id) AS musicCount " +
-            "FROM Music m " +
-            "LEFT JOIN m.posts p " +
-            "WHERE p.emotion = 'scream' " +
-            "AND p.createdAt BETWEEN :startDate AND :endDate " +
-            "GROUP BY m.id " +
-            "ORDER BY musicCount DESC")
-    List<Object[]> findScreamMusicIdsWithCountAndMusicInfo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
-
-    @Query("SELECT m.id, m.title, m.singer, m.cover, COUNT(p.music.id) AS musicCount " +
-            "FROM Music m " +
-            "LEFT JOIN m.posts p " +
-            "WHERE p.emotion = 'shy' " +
-            "AND p.createdAt BETWEEN :startDate AND :endDate " +
-            "GROUP BY m.id " +
-            "ORDER BY musicCount DESC")
-    List<Object[]> findShyMusicIdsWithCountAndMusicInfo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
-
-    @Query("SELECT m.id, m.title, m.singer, m.cover, COUNT(p.music.id) AS musicCount " +
-            "FROM Music m " +
-            "LEFT JOIN m.posts p " +
-            "WHERE p.emotion = 'happy' " +
-            "AND p.createdAt BETWEEN :startDate AND :endDate " +
-            "GROUP BY m.id " +
-            "ORDER BY musicCount DESC")
-    List<Object[]> findHappyMusicIdsWithCountAndMusicInfo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
-
-    @Query("SELECT m.id, m.title, m.singer, m.cover, COUNT(p.music.id) AS musicCount " +
-            "FROM Music m " +
-            "LEFT JOIN m.posts p " +
-            "WHERE p.emotion = 'love' " +
-            "AND p.createdAt BETWEEN :startDate AND :endDate " +
-            "GROUP BY m.id " +
-            "ORDER BY musicCount DESC")
-    List<Object[]> findLoveMusicIdsWithCountAndMusicInfo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
-
-    @Query("SELECT m.id, m.title, m.singer, m.cover, COUNT(p.music.id) AS musicCount " +
-            "FROM Music m " +
-            "LEFT JOIN m.posts p " +
-            "WHERE p.emotion = 'flex' " +
-            "AND p.createdAt BETWEEN :startDate AND :endDate " +
-            "GROUP BY m.id " +
-            "ORDER BY musicCount DESC")
-    List<Object[]> findFlexMusicIdsWithCountAndMusicInfo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+    List<Object[]> findEmotionMusicIdsWithCountAndMusicInfo(@Param("emotion") EmotionEnum emotion, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 }

--- a/src/main/java/com/paintourcolor/odle/service/MusicService.java
+++ b/src/main/java/com/paintourcolor/odle/service/MusicService.java
@@ -3,6 +3,7 @@ package com.paintourcolor.odle.service;
 import com.paintourcolor.odle.dto.mucis.response.MusicChartResponse;
 import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
 import com.paintourcolor.odle.dto.mucis.response.MusicSearchResponse;
+import com.paintourcolor.odle.entity.EmotionEnum;
 import com.paintourcolor.odle.entity.MelonKorea;
 import com.paintourcolor.odle.repository.MelonKoreaRepository;
 import com.paintourcolor.odle.repository.PostRepository;
@@ -55,92 +56,15 @@ public class MusicService implements MusicServiceInterface {
                 .collect(Collectors.toList());
     }
 
-    // angry 차트 조회
     @Transactional(readOnly = true)
     @Override
-    public List<MusicChartResponse> getAngryChart() {
+    public List<MusicChartResponse> getEmotionChart(EmotionEnum emotion) {
         // 24시간
         LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusDays(1);
+        LocalDateTime startDate = endDate.minusDays(7);
 
-        List<Object[]> musicList = postRepository.findAngryMusicIdsWithCountAndMusicInfo(startDate, endDate).stream().limit(6).toList();
+        List<Object[]> musicList = postRepository.findEmotionMusicIdsWithCountAndMusicInfo(emotion, startDate, endDate).stream().limit(6).toList();
 
-        return musicChartResponses(musicList);
-    }
-
-    // sad 차트 조회
-    @Transactional(readOnly = true)
-    @Override
-    public List<MusicChartResponse> getSadChart() {
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusDays(1);
-
-        List<Object[]> musicList = postRepository.findSadMusicIdsWithCountAndMusicInfo(startDate, endDate).stream().limit(6).toList();
-
-        return musicChartResponses(musicList);
-    }
-
-    // scream 차트 조회
-    @Transactional(readOnly = true)
-    @Override
-    public List<MusicChartResponse> getScreamChart() {
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusDays(1);
-
-        List<Object[]> musicList = postRepository.findScreamMusicIdsWithCountAndMusicInfo(startDate, endDate).stream().limit(6).toList();
-
-        return musicChartResponses(musicList);
-    }
-
-    // shy 차트 조회
-    @Transactional(readOnly = true)
-    @Override
-    public List<MusicChartResponse> getShyChart() {
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusDays(1);
-
-        List<Object[]> musicList = postRepository.findShyMusicIdsWithCountAndMusicInfo(startDate, endDate).stream().limit(6).toList();
-
-        return musicChartResponses(musicList);
-    }
-
-    // happy 차트 조회
-    @Transactional(readOnly = true)
-    @Override
-    public List<MusicChartResponse> getHappyChart() {
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusDays(1);
-
-        List<Object[]> musicList = postRepository.findHappyMusicIdsWithCountAndMusicInfo(startDate, endDate).stream().limit(6).toList();
-
-        return musicChartResponses(musicList);
-    }
-
-    // love 차트 조회
-    @Transactional(readOnly = true)
-    @Override
-    public List<MusicChartResponse> getLoveChart() {
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusDays(1);
-
-        List<Object[]> musicList = postRepository.findLoveMusicIdsWithCountAndMusicInfo(startDate, endDate).stream().limit(6).toList();
-
-        return musicChartResponses(musicList);
-    }
-
-    // flex 차트 조회
-    @Transactional(readOnly = true)
-    @Override
-    public List<MusicChartResponse> getFlexChart() {
-        LocalDateTime endDate = LocalDateTime.now();
-        LocalDateTime startDate = endDate.minusDays(1);
-
-        List<Object[]> musicList = postRepository.findFlexMusicIdsWithCountAndMusicInfo(startDate, endDate).stream().limit(6).toList();
-
-        return musicChartResponses(musicList);
-    }
-
-    public List<MusicChartResponse> musicChartResponses(List<Object[]> musicList) {
         List<MusicChartResponse> musicChartResponses = new ArrayList<>();
         for (Object[] music : musicList) {
             MusicChartResponse musicChartResponse = MusicChartResponse.builder()

--- a/src/main/java/com/paintourcolor/odle/service/MusicServiceInterface.java
+++ b/src/main/java/com/paintourcolor/odle/service/MusicServiceInterface.java
@@ -3,6 +3,7 @@ package com.paintourcolor.odle.service;
 import com.paintourcolor.odle.dto.mucis.response.MusicChartResponse;
 import com.paintourcolor.odle.dto.mucis.response.MusicResponse;
 import com.paintourcolor.odle.dto.mucis.response.MusicSearchResponse;
+import com.paintourcolor.odle.entity.EmotionEnum;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -11,13 +12,7 @@ public interface MusicServiceInterface {
     // 노래 정보 조회
     MusicResponse getMusic(Long musicId);
     List<MusicSearchResponse> getMusicSearchList(Pageable pageable, String searchOption, String keyword);
-    List<MusicChartResponse> getAngryChart();
-    List<MusicChartResponse> getSadChart();
-    List<MusicChartResponse> getScreamChart();
-    List<MusicChartResponse> getShyChart();
-    List<MusicChartResponse> getHappyChart();
-    List<MusicChartResponse> getLoveChart();
-    List<MusicChartResponse> getFlexChart();
+    List<MusicChartResponse> getEmotionChart(EmotionEnum emotion);
 //    // 감정에 대한 TOP 포스팅 노래 리스트 조회(추가기능)
 //    EmotionChartResponse getEmotionChart(EmotionChartRequest emotionChartRequest, int page);
 //    // 오늘 가장 많이 포스팅된 TOP 노래 리스트 조회(추가기능)


### PR DESCRIPTION
정적 쿼리 대신 동적 쿼리를 이용해 감정 차트에 대한 조회 코드 간소화 시켰습니다.
- MusicController
- PostRepository
- MusicService
- MusicServiceInterface

Post 엔티티에서 PostTag와 연결된 부분을 HashSet으로 변경했습니다
(정렬할 필요 없이 중복 제거만 되면 되기 때문에)